### PR TITLE
Refactor `list` subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,11 @@ fn main() {
                         .required(true),
                 ),
         )
-        .subcommand(SubCommand::with_name("list").about("Lists all existing workspaces"))
+        .subcommand(
+            SubCommand::with_name("list")
+                .alias("ls")
+                .about("Lists all existing workspaces"),
+        )
         .get_matches();
 
     if let Some(matches) = matches.subcommand_matches("new") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ extern crate clap;
 use workspace::Workspace;
 use clap::{App, Arg, ArgMatches, SubCommand};
 use std::env;
-use std::fs;
 
 fn main() {
     let matches = App::new("workspace")
@@ -32,10 +31,7 @@ fn main() {
                         .required(true),
                 ),
         )
-        .subcommand(
-            SubCommand::with_name("list")
-                .about("Lists all existing workspaces")
-        )
+        .subcommand(SubCommand::with_name("list").about("Lists all existing workspaces"))
         .get_matches();
 
     if let Some(matches) = matches.subcommand_matches("new") {
@@ -74,37 +70,12 @@ fn delete(matches: &ArgMatches) {
 }
 
 fn list() {
-    let dir_path = workspace::data_path();
-    let paths = fs::read_dir(dir_path).unwrap();
-
-    let mut workspaces: Vec<String> = Vec::new();
-    for entry in paths {
-        let path = entry.unwrap().path();
-        // assuming all yaml files are workspaces
-        // might need to change this if save other settings as yaml files
-        if file_extension_from_path(&path) == "yaml" {
-            let file_stem = file_stem_from_path(&path);
-            workspaces.push(file_stem);
-        }
-    }
-    if workspaces.len() == 0 {
+    let mut is_any = false;
+    workspace::read_all(&mut |workspace| {
+        println!("{}  {}", workspace.name, workspace.path.to_string_lossy());
+        is_any = true;
+    });
+    if !is_any {
         println!("No existing workspaces.\nRun `workspace new <NAME>` to create one.");
-    } else {
-        println!("Existing workspaces:");
-        for ws in workspaces {
-            println!("  {}", ws);
-        }
     }
-}
-
-fn file_stem_from_path(path: &std::path::PathBuf) -> String {
-    let file_stem = path.file_stem().unwrap();
-    let os_string = file_stem.to_os_string();
-    os_string.to_str().unwrap().to_string()
-}
-
-fn file_extension_from_path(path: &std::path::PathBuf) -> String {
-    let file_stem = path.extension().unwrap();
-    let os_string = file_stem.to_os_string();
-    os_string.to_str().unwrap().to_string()
 }


### PR DESCRIPTION
This implements functions to iterate workspaces using callbacks, and uses them in `list`. The functional programming approach makes it slightly more reusable, though in the future it might be appropriate to use vectors of workspaces instead. Also, `Result`s and `Option`s are now unwrapped more carefully — folders and files without extensions in the `workspace::data_path()` will no longer throw runtime errors. Finally, `list` is aliased as `ls`.