### PR TITLE
Setup CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: rust
+cache: cargo
+rust:
+  - stable
+  - beta
+  - nightly
+before_script:
+  - >
+    [ "$TRAVIS_RUST_VERSION" != "nightly" ] || rustup component add rustfmt-preview
+  - >
+    [ "$TRAVIS_RUST_VERSION" != "nightly" ] || cargo install clippy || echo "clippy failed to install"
+script:
+  - >
+    [ "$TRAVIS_RUST_VERSION" != "nightly" ] || cargo fmt -- --check
+  - >
+    [ "$TRAVIS_RUST_VERSION" != "nightly" ] || ! cargo clippy --version || cargo clippy -- -D clippy
+  - cargo build --verbose
+  - cargo test --verbose
+matrix:
+  fast_finish: true

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,10 @@ extern crate serde_derive;
 extern crate clap;
 extern crate colored;
 
-use std::env;
-use workspace::Workspace;
 use clap::{App, Arg, ArgMatches, SubCommand};
 use colored::*;
+use std::env;
+use workspace::Workspace;
 
 fn main() {
     let matches = App::new("workspace")

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,8 +1,8 @@
 extern crate serde;
 extern crate serde_yaml;
 
-use std::fs;
 use std::env;
+use std::fs;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
@@ -86,10 +86,8 @@ pub fn data_path() -> PathBuf {
     path.push(".workspace");
 
     if !path.exists() {
-        fs::create_dir(&path).expect(&format!(
-            "ERROR: Could not create directory {}",
-            path.display()
-        ));
+        fs::create_dir(&path)
+            .unwrap_or_else(|_| panic!("ERROR: Could not create directory {}", path.display()))
     }
 
     path


### PR DESCRIPTION
I added the Travis GitHub App to this repository. This sets up continuous integration with Travis, running the build and (currently zero) tests on stable, beta and nightly. On nightly, it will also run `rust-clippy` and `rustfmt`. This also fixes the linting errors from those tools

### To use rustfmt and rust-clippy locally
```bash
rustup install nightly
rustup default nightly
rustup component add rustfmt-preview
cargo install clippy
cargo fmt
cargo clippy
```