### PR TITLE
Use vectors in the workspace parsing chain

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -76,16 +76,18 @@ fn delete(matches: &ArgMatches) {
 }
 
 fn list() {
-    let mut is_any = false;
-    workspace::read_all(&mut |workspace| {
+    let all = workspace::all();
+
+    if all.is_empty() {
+        println!("No existing workspaces.\nRun `workspace new <NAME>` to create one.");
+        return;
+    }
+
+    for ws in all {
         println!(
             "{}  {}",
-            workspace.name,
-            workspace.path.display().to_string().bright_black()
+            ws.name,
+            ws.path.display().to_string().bright_black()
         );
-        is_any = true;
-    });
-    if !is_any {
-        println!("No existing workspaces.\nRun `workspace new <NAME>` to create one.");
     }
 }


### PR DESCRIPTION
Basically, the architecture of `workpace::all` is now:

- `workspace::paths` — a `Vec` of `PathBuf`s that point to workspace data files.
- `workspace::read` — takes a `PathBuf` and returns the underlying `fs::File`
- `workspace::files` — a `Vec` of workspace data `fs::File`s
- `workspace::parse` — takes a `fs::File` and parses it into a `Workspace`
- `workspace::all` — a `Vec` of all stored `Workspace`s

`files` is `paths` mapped using `read` and `all` is `files` mapped using `parse`. That way, the `open` subcommand can filter `paths` by file stem and then use `read` and `parse` only on the required workspace.