### PR TITLE
Run a specific clippy version in a new Travis job with a specific nightly version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,20 @@ rust:
   - stable
   - beta
   - nightly
-before_script:
-  - >
-    [ "$TRAVIS_RUST_VERSION" != "stable" ] || rustup toolchain install nightly-2018-06-18
-  - >
-    [ "$TRAVIS_RUST_VERSION" != "stable" ] || rustup component add rustfmt-preview --toolchain nightly-2018-06-18
-  - >
-    [ "$TRAVIS_RUST_VERSION" != "stable" ] || cargo +nightly-2018-06-18 install clippy || echo "clippy failed to install or already installed"
 script:
-  - >
-    [ "$TRAVIS_RUST_VERSION" != "stable" ] || cargo +nightly-2018-06-18 fmt -- --check
-  - >
-    [ "$TRAVIS_RUST_VERSION" != "stable" ] || ! cargo +nightly-2018-06-18 clippy --version || cargo +nightly-2018-06-18 clippy -- -D clippy
   - cargo build --verbose
   - cargo test --verbose
 matrix:
   fast_finish: true
   allow_failures:
     - rust: nightly
+  include:
+    - rust: nightly-2018-06-18
+      env:
+        - CLIPPY_VERSION=0.0.208
+      before_script:
+        - rustup component add rustfmt-preview
+        - cargo install clippy --version $CLIPPY_VERSION || echo "clippy already installed"
+      script:
+        - cargo fmt -- --check
+        - cargo clippy -- -D clippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,5 @@ script:
   - cargo test --verbose
 matrix:
   fast_finish: true
+  allow_failures:
+    - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
   - >
     [ "$TRAVIS_RUST_VERSION" != "nightly" ] || rustup component add rustfmt-preview
   - >
-    [ "$TRAVIS_RUST_VERSION" != "nightly" ] || cargo install clippy || echo "clippy failed to install"
+    [ "$TRAVIS_RUST_VERSION" != "nightly" ] || cargo install --force clippy || echo "clippy failed to install"
 script:
   - >
     [ "$TRAVIS_RUST_VERSION" != "nightly" ] || cargo fmt -- --check

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,16 @@ rust:
   - nightly
 before_script:
   - >
-    [ "$TRAVIS_RUST_VERSION" != "nightly" ] || rustup component add rustfmt-preview
+    [ "$TRAVIS_RUST_VERSION" != "stable" ] || rustup toolchain install nightly-2018-06-18
   - >
-    [ "$TRAVIS_RUST_VERSION" != "nightly" ] || cargo install --force clippy || echo "clippy failed to install"
+    [ "$TRAVIS_RUST_VERSION" != "stable" ] || rustup component add rustfmt-preview --toolchain nightly-2018-06-18
+  - >
+    [ "$TRAVIS_RUST_VERSION" != "stable" ] || cargo +nightly-2018-06-18 install clippy || echo "clippy failed to install or already installed"
 script:
   - >
-    [ "$TRAVIS_RUST_VERSION" != "nightly" ] || cargo fmt -- --check
+    [ "$TRAVIS_RUST_VERSION" != "stable" ] || cargo +nightly-2018-06-18 fmt -- --check
   - >
-    [ "$TRAVIS_RUST_VERSION" != "nightly" ] || ! cargo clippy --version || cargo clippy -- -D clippy
+    [ "$TRAVIS_RUST_VERSION" != "stable" ] || ! cargo +nightly-2018-06-18 clippy --version || cargo +nightly-2018-06-18 clippy -- -D clippy
   - cargo build --verbose
   - cargo test --verbose
 matrix:


### PR DESCRIPTION
Fixes #19. Clippy needs to run with the same version of Rust it was compiled with. Recompiling clippy on every build seems to be the best solution currently, even though it slows down the build. In the future we might pick a nightly where clippy works, compile it once, cache it, and always use that nightly to invoke it.