### PR TITLE
Add `shell` subcommand

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,0 +1,34 @@
+pub const BASH: &str = "function ws {
+    while read -r line; do
+        if [[ \"$line\" == \"RUN>*\" ]]; then
+            source <(echo \"${line:4}\");
+        else
+            echo \"$line\";
+        fi;
+    done < <( workspace \"$@\" );
+}";
+
+pub const POWERSHELL: &str = "function ws {
+    workspace $args | % {
+        if ($_ -match \"^RUN>\") {
+            . ([scriptblock]::Create($_.Substring(4)))
+        } else {
+            Write-Output $_
+        }
+    }
+}";
+
+pub const CMD: &str = "@ECHO off
+FOR /F \"tokens=* delims=\" %%G IN ('workspace %*') DO (
+    CALL :subroutine \"%%G\"
+)
+GOTO :EOF
+
+:subroutine
+    SET \"temp=%~1\"
+    IF \"%temp:~0,4%\" == \"RUN>\" (
+        CALL %temp:~4%
+    ) ELSE (
+        ECHO %~1
+    )
+    GOTO :EOF";

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,9 +1,9 @@
 pub const BASH: &str = "function ws {
     while read -r line; do
-        if [[ \"$line\" == \"RUN>*\" ]]; then
-            source <(echo \"${line:4}\");
+        if [[ $line == RUN\\>* ]]; then
+            eval ${line:4};
         else
-            echo \"$line\";
+            echo $line;
         fi;
     done < <( workspace \"$@\" );
 }";


### PR DESCRIPTION
Now we can invoke commands that should run directly in the user's current shell, which allows us to change the working directory, and lets users specify commands for workspaces that change environment variables (this closes #10). To run, say, `cd /`, in the user's shell, we have to:
```rust
println!("RUN>cd /");
```

### Setup
- **bash**: Add this to your `.bashrc`: 
```bash
source <(workspace shell bash)
```
- **PowerShell**: Add this to your `profile.ps1`
```powershell
Invoke-Expression "$(workspace shell powershell)"
```
- **cmd**: Just run `workspace shell cmd`. This will create a `.bat` file next to the workspace binary (we know for sure it's in the PATH).

***

I updated the cmd version since I commented on #10, such that it preserves leading whitespace and displays parentheses, and runs everything directly in the shell process instead of just changing the directory with the `pushd`/`popd` hack. It seems to still choke on some special characters though (like `}` for example). The Powershell version works like a charm.

I haven't tested the bash version. @roma0615 could you please? Just add
```rust
println!("RUN>cd /");
println!("RUN>ls");
```
at the end of `main::list`. Then run `ws list` and check that the working directory is actually changed in your shell.

NB: only the Travis PR build matters here since we fixed the CI after this was branched from master.