### PR TITLE
Align columns in `list`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,11 +118,13 @@ fn list() {
         println!("No existing workspaces.\nRun `workspace new <NAME>` to create one.");
         return;
     }
-
+    
+    let l = (*all).iter().max_by(|ws1, ws2| ws1.name.len().cmp(&mut ws2.name.len())).unwrap().name.len();
     for ws in all {
         println!(
-            "{}  {}",
+            "{0:<1$}  {2}",
             ws.name,
+            l,
             ws.path.display().to_string().bright_black()
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,13 +118,13 @@ fn list() {
         println!("No existing workspaces.\nRun `workspace new <NAME>` to create one.");
         return;
     }
-    
-    let l = (*all).iter().max_by(|ws1, ws2| ws1.name.len().cmp(&mut ws2.name.len())).unwrap().name.len();
+
+    let longest_name_length = (*all).iter().map(|ws| ws.name.len()).fold(0, std::cmp::max);
     for ws in all {
         println!(
             "{0:<1$}  {2}",
             ws.name,
-            l,
+            longest_name_length,
             ws.path.display().to_string().bright_black()
         );
     }


### PR DESCRIPTION
In order to format the columns correctly, it first gets the length of the longest workspace name. It then uses this length to format the columns correctly (see `std::fmt`'s [fill/alignment](https://doc.rust-lang.org/std/fmt/#fillalignment)).
This closes #14.

@matthias-t could you make sure [the line that gets the longest length](https://github.com/matthias-t/workspace/blob/c38e3d22214c1ad18d575e4973e1ac2df25273fc/src/main.rs#L122) isn't too convoluted? I somehow got it to work, but I'm wondering if there's a better way.