### PR TITLE
Put quotes around $line to fix formatting problem in bash

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -3,7 +3,7 @@ pub const BASH: &str = "function ws {
         if [[ $line == RUN\\>* ]]; then
             eval ${line:4};
         else
-            echo $line;
+            echo \"$line\";
         fi;
     done < <( workspace \"$@\" );
 }";


### PR DESCRIPTION
This fixes #27. Using `$line` without quotes splits the contents of the string, losing all formatting, whereas using `"$line"` preserves whitespace and formatting.