### PR TITLE
Improved error handling and listing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ colored = "1.6.0"
 serde = "1.0.62"
 serde_derive = "1.0.62"
 toml = "0.4"
+failure = "0.1.1"
 
 [[bin]]
 name = "workspace"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ serde = "1.0.62"
 serde_derive = "1.0.62"
 toml = "0.4"
 failure = "0.1.1"
+prettytable-rs = "0.7.0"
 
 [[bin]]
 name = "workspace"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ serde = "1.0.62"
 serde_derive = "1.0.62"
 toml = "0.4"
 failure = "0.1.1"
-prettytable-rs = "0.7.0"
+prettytable-rs = { git = "https://github.com/liautaud/prettytable-rs" }
 
 [[bin]]
 name = "workspace"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,6 +11,12 @@ macro_rules! error {
     };
 }
 
+macro_rules! indent_error {
+    ($message:expr$(,$arg:expr)*) => {
+        eprintln!(concat!("       ", $message)$(, $arg)*);
+    };
+}
+
 // Dependencies: colored::Colorize
 macro_rules! warn {
     ($message:expr$(,$arg:expr)*) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,23 +90,42 @@ fn list() {
         return;
     }
 
-    let longest_name_length = (*all).iter().map(|ws| ws.name.len()).fold(0, std::cmp::max);
-    let longest_path_length = (*all)
+    let rows: Vec<(&String, String, String)> = all
         .iter()
-        .map(|ws| ws.path.display().to_string().len())
-        .fold(0, std::cmp::max);
-    for ws in all {
+        .map(|(name, result)| {
+            let path: String;
+            let mut moved: String = String::default();
+            match result {
+                Ok(ws) => {
+                    path = ws.path.display().to_string();
+                    if !ws.path.exists() {
+                        moved = format!("  {} path has moved", "warning:".bold().yellow());
+                    }
+                }
+                Err(error) => {
+                    path = format!("{} {}", "warning:".bold().yellow(), error.cause());
+                }
+            }
+            (name, path, moved)
+        })
+        .collect();
+
+    use std::cmp::max;
+    let (longest_name_length, longest_path_length) = rows
+        .iter()
+        .map(|(name, path, _)| (name.len(), path.len()))
+        .fold((0, 0), |(name1, path1), (name2, path2)| {
+            (max(name1, name2), max(path1, path2))
+        });
+
+    for (name, path, moved) in rows {
         println!(
             "{0:<1$}  {2:<3$}{4}",
-            ws.name,
+            name,
             longest_name_length,
-            ws.path.display().to_string().bright_black(),
+            path.bright_black(),
             longest_path_length,
-            if !ws.path.exists() {
-                format!("  {} path has moved", "warning:".bold().yellow())
-            } else {
-                String::default()
-            }
+            moved
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,9 +51,7 @@ fn open(matches: &ArgMatches) {
     let result = workspace::get(name)
         .unwrap_or_exit(&format!("A workspace called '{}' does not exist", name));
     let ws = result.unwrap_or_else(|error| {
-        let cause = error
-            .cause()
-            .map_or(String::default(), |cause| cause.to_string());
+        let cause = error.cause().map_or(String::default(), Fail::to_string);
         let path = workspace::file_path(name);
         error!("{} from {}", error, path.display());
         indent_error!("{}", cause);

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,10 +48,10 @@ fn main() {
 
 fn open(matches: &ArgMatches) {
     let name: &str = matches.value_of("NAME").unwrap();
-    let result = workspace::get(name)
+    let result = Workspace::get(name)
         .unwrap_or_exit(&format!("A workspace called '{}' does not exist", name));
     let ws = result.unwrap_or_else(|error| {
-        let path = workspace::file_path(name);
+        let path = Workspace::file_path(name);
         error!("{} from {}", error, path.display());
         if let Some(cause) = error.cause() {
             indent_error!("{}", cause);
@@ -71,14 +71,14 @@ fn open(matches: &ArgMatches) {
 
 fn add(matches: &ArgMatches) {
     let name = matches.value_of("NAME").unwrap().to_string();
-    if workspace::exists(&name) {
+    if Workspace::exists(&name) {
         error!("A workspace called '{}' already exists", name);
         process::exit(1);
     }
     let ws = Workspace {
         path: env::current_dir().unwrap_or_exit("Could not read current directory"),
     };
-    workspace::write(&ws, &name);
+    ws.write(&name);
     println!("Created workspace '{}' in {}", name, ws.path.display());
 }
 
@@ -89,12 +89,12 @@ fn delete(matches: &ArgMatches) {
         confirm!("delete the workspace '{}'", name);
     }
 
-    workspace::delete(name);
+    Workspace::delete(name);
     println!("Deleted workspace '{}'", name);
 }
 
 fn list() {
-    let all = workspace::all();
+    let all = Workspace::all();
     if all.is_empty() {
         println!("No existing workspaces.\nRun `workspace add <NAME>` to create one.");
         return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,8 @@ fn open(matches: &ArgMatches) {
             .cause()
             .map_or(String::default(), |cause| cause.to_string());
         let path = workspace::file_path(name);
-        error!("{} from {}\n       {}", error, path.display(), cause);
+        error!("{} from {}", error, path.display());
+        indent_error!("{}", cause);
         if let Some(backtrace) = error.backtrace() {
             log!("{}", backtrace);
         }
@@ -63,7 +64,7 @@ fn open(matches: &ArgMatches) {
     });
     if !ws.path.exists() {
         error!("The location of this workspace does not exist anymore");
-        println!("The path '{}' was moved or deleted", ws.path.display());
+        indent_error!("the path '{}' was moved or deleted", ws.path.display());
         process::exit(1);
     }
     ws.open();

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,20 +53,20 @@ fn open(matches: &ArgMatches) {
         println!("The path '{}' was moved or deleted", ws.path.display());
         process::exit(1);
     }
-    ws.cd();
+    ws.open();
 }
 
 fn add(matches: &ArgMatches) {
-    let ws = Workspace {
-        name: matches.value_of("NAME").unwrap().to_string(),
-        path: env::current_dir().unwrap_or_exit("Could not read current directory"),
-    };
-    if ws.exists() {
-        error!("A workspace called '{}' already exists", ws.name);
+    let name = matches.value_of("NAME").unwrap().to_string();
+    if workspace::exists(&name) {
+        error!("A workspace called '{}' already exists", name);
         process::exit(1);
     }
-    ws.write();
-    println!("Created workspace '{}' in {}", ws.name, ws.path.display());
+    let ws = Workspace {
+        path: env::current_dir().unwrap_or_exit("Could not read current directory"),
+    };
+    workspace::write(ws, &name);
+    println!("Created workspace '{}' in {}", name, ws.path.display());
 }
 
 fn delete(matches: &ArgMatches) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,10 +51,11 @@ fn open(matches: &ArgMatches) {
     let result = workspace::get(name)
         .unwrap_or_exit(&format!("A workspace called '{}' does not exist", name));
     let ws = result.unwrap_or_else(|error| {
-        let cause = error.cause().map_or(String::default(), Fail::to_string);
         let path = workspace::file_path(name);
         error!("{} from {}", error, path.display());
-        indent_error!("{}", cause);
+        if let Some(cause) = error.cause() {
+            indent_error!("{}", cause);
+        }
         if let Some(backtrace) = error.backtrace() {
             log!("{}", backtrace);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn add(matches: &ArgMatches) {
     let ws = Workspace {
         path: env::current_dir().unwrap_or_exit("Could not read current directory"),
     };
-    workspace::write(ws, &name);
+    workspace::write(&ws, &name);
     println!("Created workspace '{}' in {}", name, ws.path.display());
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,20 +92,21 @@ fn list() {
     let rows: Vec<Row> = all
         .iter()
         .map(|(name, result)| {
-            let path: String;
-            let mut moved: String = String::default();
+            let path: Cell;
+            let mut moved = Cell::new("");
             match result {
                 Ok(ws) => {
-                    path = ws.path.display().to_string();
+                    path = Cell::new(&ws.path.display().to_string().bright_black().to_string());
                     if !ws.path.exists() {
-                        moved = format!("  {} path has moved", "warning:".bold().yellow());
+                        moved =
+                            Cell::new(&format!("{} path has moved", "warning:".bold().yellow()));
                     }
                 }
                 Err(error) => {
-                    path = format!("{} {}", "warning:".bold().yellow(), error.cause());
+                    path = Cell::new(&format!("{} {}", "warning:".bold().yellow(), error.cause()));
                 }
             }
-            Row::new(vec![Cell::new(name), Cell::new(&path), Cell::new(&moved)])
+            Row::new(vec![Cell::new(name), path, moved])
         })
         .collect();
     let mut table = Table::init(rows);

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,11 +118,8 @@ fn list() {
                     path = Cell::new(&format!("{} {}", "warning:".bold().yellow(), error));
                 }
             }
-            let invalid = &format!("{} invalid UTF-8", "warning:".bold().yellow());
-            let name = Cell::new(match name {
-                Some(name) => name,
-                None => invalid,
-            });
+            let invalid = format!("{} invalid UTF-8", "warning:".bold().yellow());
+            let name = Cell::new(name.as_ref().unwrap_or(&invalid).as_str());
             Row::new(vec![name, path, moved])
         })
         .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,15 +71,13 @@ fn add(matches: &ArgMatches) {
 
 fn delete(matches: &ArgMatches) {
     let name: &str = matches.value_of("NAME").unwrap();
-    let ws: Workspace = workspace::get(name)
-        .unwrap_or_exit(&format!("A workspace called '{}' does not exist", name));
 
     if !matches.is_present("yes") {
-        confirm!("delete the workspace '{}'", ws.name);
+        confirm!("delete the workspace '{}'", name);
     }
 
-    ws.delete();
-    println!("Deleted workspace '{}' in {}", ws.name, ws.path.display());
+    workspace::delete(name);
+    println!("Deleted workspace '{}'", name);
 }
 
 fn list() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,12 @@ fn list() {
                     path = Cell::new(&format!("{} {}", "warning:".bold().yellow(), error.cause()));
                 }
             }
-            Row::new(vec![Cell::new(name), path, moved])
+            let invalid = &format!("{} invalid UTF-8", "warning:".bold().yellow());
+            let name = Cell::new(match name {
+                Some(name) => name,
+                None => invalid,
+            });
+            Row::new(vec![name, path, moved])
         })
         .collect();
     let mut table = Table::init(rows);

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn list() {
                     }
                 }
                 Err(error) => {
-                    path = Cell::new(&format!("{} {}", "warning:".bold().yellow(), error.cause()));
+                    path = Cell::new(&format!("{} {}", "warning:".bold().yellow(), error));
                 }
             }
             let invalid = &format!("{} invalid UTF-8", "warning:".bold().yellow());

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ mod workspace;
 
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate failure;
 extern crate clap;
 extern crate colored;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,13 +48,17 @@ fn main() {
 
 fn open(matches: &ArgMatches) {
     let name: &str = matches.value_of("NAME").unwrap();
-    let ws = workspace::get(name)
+    let result = workspace::get(name)
         .unwrap_or_exit(&format!("A workspace called '{}' does not exist", name));
-    let ws = ws.unwrap_or_else(|error| {
+    let ws = result.unwrap_or_else(|error| {
         let cause = error
             .cause()
             .map_or(String::default(), |cause| cause.to_string());
-        error!("{} — {}", error, cause);
+        let path = workspace::file_path(name);
+        error!("{} from {}\n       {}", error, path.display(), cause);
+        if let Some(backtrace) = error.backtrace() {
+            log!("{}", backtrace);
+        }
         process::exit(1)
     });
     if !ws.path.exists() {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -21,7 +21,7 @@ impl Workspace {
     }
 }
 
-pub fn write(ws: Workspace, name: &str) {
+pub fn write(ws: &Workspace, name: &str) {
     const ERR_MESSAGE: &str = "Could not write workspace data";
 
     let path = file_path(name);
@@ -32,7 +32,7 @@ pub fn write(ws: Workspace, name: &str) {
         .open(path)
         .unwrap_or_exit(ERR_MESSAGE);
 
-    let serialized = toml::to_string(&ws).unwrap();
+    let serialized = toml::to_string(ws).unwrap();
     file.write_fmt(format_args!("{}", serialized))
         .unwrap_or_exit(ERR_MESSAGE);
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -127,7 +127,10 @@ fn paths() -> Vec<PathBuf> {
 }
 
 fn file_path(name: &str) -> PathBuf {
-    folder_path().with_file_name(name).with_extension("toml")
+    let mut path = folder_path();
+    path.push(name);
+    path.set_extension("toml");
+    path
 }
 
 fn folder_path() -> PathBuf {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -18,123 +18,124 @@ impl Workspace {
     pub fn open(&self) {
         run!("cd {}", self.path.display());
     }
-}
 
-pub fn write(ws: &Workspace, name: &str) {
-    const ERR_MESSAGE: &str = "Could not write workspace data";
+    pub fn write(&self, name: &str) {
+        const ERR_MESSAGE: &str = "Could not write workspace data";
 
-    let path = file_path(name);
-    let mut file = fs::OpenOptions::new()
-        .read(false)
-        .write(true)
-        .create(true)
-        .open(path)
-        .unwrap_or_exit(ERR_MESSAGE);
+        let path = Self::file_path(name);
+        let mut file = fs::OpenOptions::new()
+            .read(false)
+            .write(true)
+            .create(true)
+            .open(path)
+            .unwrap_or_exit(ERR_MESSAGE);
 
-    let serialized = toml::to_string(ws).unwrap();
-    file.write_fmt(format_args!("{}", serialized))
-        .unwrap_or_exit(ERR_MESSAGE);
-}
-
-pub fn delete(name: &str) {
-    let path = file_path(name);
-    fs::remove_file(path).unwrap_or_exit("Could not delete workspace data");
-}
-
-pub fn exists(name: &str) -> bool {
-    file_path(name).exists()
-}
-
-pub fn get(name: &str) -> Option<Result<Workspace, Error>> {
-    let path = file_path(name);
-    if !path.exists() {
-        None
-    } else {
-        Some(parse(&path))
-    }
-}
-
-pub fn all() -> Vec<(Option<String>, Result<Workspace, Error>)> {
-    paths()
-        .into_iter()
-        .map(|path| {
-            // Safe to unwrap here, because paths() cannot contain a file without a stem
-            let name = path.file_stem().unwrap().to_str().map(str::to_owned);
-            (name, path)
-        })
-        .map(|(name, path)| (name, parse(&path)))
-        .collect()
-}
-
-fn parse(path: &PathBuf) -> Result<Workspace, Error> {
-    let content: String = read(&path)?;
-    let ws: Workspace = toml::from_str(&content)?;
-    Ok(ws)
-}
-
-fn read(path: &PathBuf) -> io::Result<String> {
-    let mut content: String = String::new();
-
-    fs::OpenOptions::new()
-        .read(true)
-        .open(&path)?
-        .read_to_string(&mut content)?;
-
-    Ok(content)
-}
-
-fn paths() -> Vec<PathBuf> {
-    let entries = fs::read_dir(folder_path()).unwrap_or_exit("Could not find workspace data");
-    let mut paths: Vec<PathBuf> = Vec::new();
-
-    for entry in entries {
-        skip_err!(entry);
-        let entry = entry.unwrap();
-        let path = entry.path();
-
-        skip_err!(entry.file_type());
-        let file_type = entry.file_type().unwrap();
-        skip!(
-            !file_type.is_file(),
-            format!("Skipping {} because it's not a file", path.display())
-        );
-
-        skip_none!(
-            path.extension(),
-            format!(
-                "Skipping {} because it has no file extension",
-                path.display()
-            )
-        );
-        let extension = path.extension().unwrap();
-        skip!(
-            extension.to_string_lossy() != "toml",
-            format!("Skipping {} because it's not a TOML file", path.display())
-        );
-
-        paths.push(entry.path());
+        let serialized = toml::to_string(self).unwrap();
+        file.write_fmt(format_args!("{}", serialized))
+            .unwrap_or_exit(ERR_MESSAGE);
     }
 
-    paths
-}
-
-pub fn file_path(name: &str) -> PathBuf {
-    let mut path = folder_path();
-    path.push(name);
-    path.set_extension("toml");
-    path
-}
-
-fn folder_path() -> PathBuf {
-    let mut path = env::home_dir().unwrap_or_exit("Could not find home directory");
-    path.push(".workspace");
-
-    if !path.exists() {
-        fs::create_dir(&path)
-            .unwrap_or_exit(&format!("Could not create directory {}", path.display()));
+    pub fn delete(name: &str) {
+        let path = Self::file_path(name);
+        fs::remove_file(path).unwrap_or_exit("Could not delete workspace data");
     }
 
-    path
+    pub fn exists(name: &str) -> bool {
+        Self::file_path(name).exists()
+    }
+
+    pub fn get(name: &str) -> Option<Result<Workspace, Error>> {
+        let path = Self::file_path(name);
+        if !path.exists() {
+            None
+        } else {
+            Some(Self::parse(&path))
+        }
+    }
+
+    pub fn all() -> Vec<(Option<String>, Result<Workspace, Error>)> {
+        Self::paths()
+            .into_iter()
+            .map(|path| {
+                // Safe to unwrap here, because paths() cannot contain a file without a stem
+                let name = path.file_stem().unwrap().to_str().map(str::to_owned);
+                (name, path)
+            })
+            .map(|(name, path)| (name, Self::parse(&path)))
+            .collect()
+    }
+
+    fn parse(path: &PathBuf) -> Result<Workspace, Error> {
+        let content: String = Self::read(&path)?;
+        let ws: Workspace = toml::from_str(&content)?;
+        Ok(ws)
+    }
+
+    fn read(path: &PathBuf) -> io::Result<String> {
+        let mut content: String = String::new();
+
+        fs::OpenOptions::new()
+            .read(true)
+            .open(&path)?
+            .read_to_string(&mut content)?;
+
+        Ok(content)
+    }
+
+    fn paths() -> Vec<PathBuf> {
+        let entries =
+            fs::read_dir(Self::folder_path()).unwrap_or_exit("Could not find workspace data");
+        let mut paths: Vec<PathBuf> = Vec::new();
+
+        for entry in entries {
+            skip_err!(entry);
+            let entry = entry.unwrap();
+            let path = entry.path();
+
+            skip_err!(entry.file_type());
+            let file_type = entry.file_type().unwrap();
+            skip!(
+                !file_type.is_file(),
+                format!("Skipping {} because it's not a file", path.display())
+            );
+
+            skip_none!(
+                path.extension(),
+                format!(
+                    "Skipping {} because it has no file extension",
+                    path.display()
+                )
+            );
+            let extension = path.extension().unwrap();
+            skip!(
+                extension.to_string_lossy() != "toml",
+                format!("Skipping {} because it's not a TOML file", path.display())
+            );
+
+            paths.push(entry.path());
+        }
+
+        paths
+    }
+
+    pub fn file_path(name: &str) -> PathBuf {
+        let mut path = Self::folder_path();
+        path.push(name);
+        path.set_extension("toml");
+        path
+    }
+
+    fn folder_path() -> PathBuf {
+        let mut path = env::home_dir().unwrap_or_exit("Could not find home directory");
+        path.push(".workspace");
+
+        if !path.exists() {
+            fs::create_dir(&path)
+                .unwrap_or_exit(&format!("Could not create directory {}", path.display()));
+        }
+
+        path
+    }
 }
 
 #[derive(Fail, Debug)]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -50,7 +50,7 @@ pub fn get(name: &str) -> Result<Workspace, Error> {
     parse(file_path(name))
 }
 
-pub fn all() -> Vec<(String, Result<Workspace, Error>)> {
+pub fn all() -> Vec<(Option<String>, Result<Workspace, Error>)> {
     paths()
         .into_iter()
         .map(|path| {
@@ -59,11 +59,7 @@ pub fn all() -> Vec<(String, Result<Workspace, Error>)> {
                 .file_stem()
                 .unwrap()
                 .to_str()
-                .map(|slice| slice.to_string())
-                .unwrap_or(format!(
-                    "{} workspace name is invalid UTF-8",
-                    "warning:".bold().yellow()
-                ));
+                .map(|slice| slice.to_string());
             (name, path)
         })
         .map(|(name, path)| (name, parse(path)))

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -59,11 +59,7 @@ pub fn all() -> Vec<(Option<String>, Result<Workspace, Error>)> {
         .into_iter()
         .map(|path| {
             // Safe to unwrap here, because paths() cannot contain a file without a stem
-            let name = path
-                .file_stem()
-                .unwrap()
-                .to_str()
-                .map(|slice| slice.to_string());
+            let name = path.file_stem().unwrap().to_str().map(str::to_owned);
             (name, path)
         })
         .map(|(name, path)| (name, parse(&path)))

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -50,7 +50,7 @@ pub fn get(name: &str) -> Option<Result<Workspace, Error>> {
     if !path.exists() {
         None
     } else {
-        Some(parse(path))
+        Some(parse(&path))
     }
 }
 
@@ -66,22 +66,22 @@ pub fn all() -> Vec<(Option<String>, Result<Workspace, Error>)> {
                 .map(|slice| slice.to_string());
             (name, path)
         })
-        .map(|(name, path)| (name, parse(path)))
+        .map(|(name, path)| (name, parse(&path)))
         .collect()
 }
 
-fn parse(path: PathBuf) -> Result<Workspace, Error> {
-    let content: String = read(path)?;
+fn parse(path: &PathBuf) -> Result<Workspace, Error> {
+    let content: String = read(&path)?;
     let ws: Workspace = toml::from_str(&content)?;
     Ok(ws)
 }
 
-fn read(path: PathBuf) -> io::Result<String> {
+fn read(path: &PathBuf) -> io::Result<String> {
     let mut content: String = String::new();
 
     fs::OpenOptions::new()
         .read(true)
-        .open(path)?
+        .open(&path)?
         .read_to_string(&mut content)?;
 
     Ok(content)
@@ -122,7 +122,7 @@ fn paths() -> Vec<PathBuf> {
     paths
 }
 
-fn file_path(name: &str) -> PathBuf {
+pub fn file_path(name: &str) -> PathBuf {
     let mut path = folder_path();
     path.push(name);
     path.set_extension("toml");

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -4,7 +4,6 @@ extern crate toml;
 use super::exit::Exit;
 use super::VERBOSE;
 use colored::*;
-use failure::Error;
 use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
@@ -135,4 +134,24 @@ fn folder_path() -> PathBuf {
     }
 
     path
+}
+
+#[derive(Fail, Debug)]
+pub enum Error {
+    #[fail(display = "Could not read workspace data")]
+    Read(#[cause] io::Error),
+    #[fail(display = "Could not parse workspace data")]
+    Parse(#[cause] toml::de::Error),
+}
+
+impl From<io::Error> for Error {
+    fn from(cause: io::Error) -> Error {
+        Error::Read(cause)
+    }
+}
+
+impl From<toml::de::Error> for Error {
+    fn from(cause: toml::de::Error) -> Error {
+        Error::Parse(cause)
+    }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -12,42 +12,38 @@ use std::path::PathBuf;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Workspace {
-    pub name: String,
     pub path: PathBuf,
 }
 
 impl Workspace {
-    pub fn write(&self) -> &Self {
-        const ERR_MESSAGE: &str = "Could not write workspace data";
-
-        let path = file_path(&self.name);
-        let mut file = fs::OpenOptions::new()
-            .read(false)
-            .write(true)
-            .create(true)
-            .open(path)
-            .unwrap_or_exit(ERR_MESSAGE);
-
-        let serialized = toml::to_string(self).unwrap();
-        file.write_fmt(format_args!("{}", serialized))
-            .unwrap_or_exit(ERR_MESSAGE);
-
-        self
-    }
-
-    pub fn delete(&self) -> &Self {
-        let path = file_path(&self.name);
-        fs::remove_file(path).unwrap_or_exit("Could not delete workspace data");
-        self
-    }
-
-    pub fn exists(&self) -> bool {
-        file_path(&self.name).exists()
-    }
-
-    pub fn cd(&self) {
+    pub fn open(&self) {
         run!("cd {}", self.path.display());
     }
+}
+
+pub fn write(ws: Workspace, name: &str) {
+    const ERR_MESSAGE: &str = "Could not write workspace data";
+
+    let path = file_path(name);
+    let mut file = fs::OpenOptions::new()
+        .read(false)
+        .write(true)
+        .create(true)
+        .open(path)
+        .unwrap_or_exit(ERR_MESSAGE);
+
+    let serialized = toml::to_string(&ws).unwrap();
+    file.write_fmt(format_args!("{}", serialized))
+        .unwrap_or_exit(ERR_MESSAGE);
+}
+
+pub fn delete(name: &str) {
+    let path = file_path(name);
+    fs::remove_file(path).unwrap_or_exit("Could not delete workspace data");
+}
+
+pub fn exists(name: &str) -> bool {
+    file_path(name).exists()
 }
 
 pub fn get(name: &str) -> Result<Workspace, Error> {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -5,6 +5,8 @@ use super::exit::Exit;
 use super::VERBOSE;
 use colored::*;
 use std::env;
+use std::error;
+use std::fmt;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
@@ -131,4 +133,27 @@ fn folder_path() -> PathBuf {
     }
 
     path
+}
+
+#[derive(Debug, Clone)]
+struct Error {
+    name: String,
+    description: &'static str,
+    cause: Option<&'static error::Error>,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        use std::error::Error;
+        write!(formatter, "{}", self.description())
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        self.description
+    }
+    fn cause(&self) -> Option<&error::Error> {
+        self.cause
+    }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -6,7 +6,7 @@ use super::VERBOSE;
 use colored::*;
 use std::env;
 use std::fs;
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 use std::path::PathBuf;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -71,11 +71,15 @@ pub fn files() -> Vec<fs::File> {
     paths().into_iter().map(read).collect()
 }
 
-pub fn read(path: PathBuf) -> fs::File {
+fn read(path: PathBuf) -> io::Result<String> {
+    let mut content: String = String::new();
+
     fs::OpenOptions::new()
         .read(true)
-        .open(path)
-        .unwrap_or_exit("Could not get workspace data")
+        .open(path)?
+        .read_to_string(&mut content)?;
+
+    Ok(content)
 }
 
 fn paths() -> Vec<PathBuf> {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -45,8 +45,13 @@ pub fn exists(name: &str) -> bool {
     file_path(name).exists()
 }
 
-pub fn get(name: &str) -> Result<Workspace, Error> {
-    parse(file_path(name))
+pub fn get(name: &str) -> Option<Result<Workspace, Error>> {
+    let path = file_path(name);
+    if !path.exists() {
+        None
+    } else {
+        Some(parse(path))
+    }
 }
 
 pub fn all() -> Vec<(Option<String>, Result<Workspace, Error>)> {


### PR DESCRIPTION
- Use the `failure` crate to improve error handling (close #41)
- Remove the `name` field (close #44)
- Optimize `workspace::get` (close #45)
- Use a fork of `prettytable-rs` to fix the alignment of `list` (close #46)
- Since it is no longer relevant, close #13

I'm sorry that this turned out to be such a big PR.